### PR TITLE
fix: update CI workflows to resolve common failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, phase-1-foundations]
   pull_request:
-    branches: [main, develop]
+    branches: [main, phase-1-foundations]
 
 jobs:
   test:
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -43,12 +43,13 @@ jobs:
         run: mypy src/
 
       - name: Test with pytest
-        run: pytest --cov=src/oasis --cov-report=xml --cov-report=term-missing
+        run: pytest --cov=src/oasis --cov-report=xml --cov-report=term-missing --cov-fail-under=80
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        continue-on-error: true
         with:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -2,9 +2,9 @@ name: Contracts
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, phase-1-foundations]
   pull_request:
-    branches: [main, develop]
+    branches: [main, phase-1-foundations]
 
 jobs:
   contracts:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, phase-1-foundations]
   pull_request:
-    branches: [main, develop]
+    branches: [main, phase-1-foundations]
 
 jobs:
   security:
@@ -57,7 +57,7 @@ jobs:
           trivy fs . --format table --severity HIGH,CRITICAL
 
       - name: Upload security audit results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: security-audit-results


### PR DESCRIPTION
- Update branch triggers from 'develop' to 'phase-1-foundations'
- Update actions/cache@v3 to @v4 (fixes deprecation warnings)
- Update actions/upload-artifact@v3 to @v4 (fixes deprecation warnings)
- Add --cov-fail-under=80 to pytest command for coverage enforcement
- Make Codecov upload non-blocking with continue-on-error: true
- Fix fail_ci_if_error: false to prevent Codecov rate limit failures

Resolves: Multiple CI failures across workflows